### PR TITLE
Add support for configuring Chuck via environment variables as well

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -3,6 +3,9 @@
 const extend = require('extend');
 const uConfig = require('../configs/config.json');
 const eConfig = require('../configs/default.json');
+const envUtil = require('../utils/env.js');
+
+const envConfig = new envUtil().parse(eConfig);
 const target = {};
 /* 
  * deep Boolean (optional) If set, the merge becomes recursive (i.e. deep copy).
@@ -10,6 +13,6 @@ const target = {};
  * object1 Object The object that will be merged into the first.
  * objectN Object (Optional) More objects to merge into the first.
 */
-extend(true, target, eConfig, uConfig);
 
+extend(true, target, eConfig, uConfig, envConfig);
 module.exports = target;

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,50 @@
+'use strict';
+
+class EnvUtil {
+    constructor() {
+        this.envConfig = {};
+    }
+
+    isNumeric(value) {
+        return /^-?\d+$/.test(value);
+    }
+
+    assignValue(key, value) {
+        var arr = key.toLowerCase().split('_');
+        var i = 0;
+        var curobj = this.envConfig;
+        while (i < (arr.length - 1)) {
+            if (curobj[arr[i]] === undefined) {
+                curobj[arr[i]] = {};
+            }
+            curobj = curobj[arr[i++]];
+        }
+        if (this.isNumeric(value)) {
+            curobj[arr[i]] = +value;
+        } else {
+            curobj[arr[i]] = value;
+        }
+    }
+
+    parse(configJson, parent = "") {
+        Object.keys(configJson).forEach(key => {
+            let newParent = "";
+            if (parent != "") {
+                newParent = parent + "_" + key.toUpperCase();
+            } else {
+                newParent = key.toUpperCase();
+            }
+            if (typeof configJson[key] === 'object') {
+                this.parse(configJson[key], newParent);
+            }
+            else {
+                this.assignValue(newParent, process.env[newParent]);
+            }
+        })
+
+        return this.envConfig;
+    }
+
+}
+
+module.exports = EnvUtil;


### PR DESCRIPTION
This allows users to provide configuration via environment variables as well. So if the user wants to specify a db password, they can just pass that as `DB_PASSWORD`. So they just have to add underscore `_` to every nested level and make the name of the config field uppercase. Like setting the host will be as simple as setting `HOST` since it is top level. But setting something like dataparser.port, they have to use `DATAPARSER_PORT` env variable. I hope this makes it clear on how to use it