### PR TITLE
Reduce false negatives of futureproof PvP ranks

### DIFF
--- a/src/services/pvp-core.js
+++ b/src/services/pvp-core.js
@@ -7,8 +7,8 @@ const cpMultipliers = require('../../static/data/cp_multiplier.json');
  * Use ./pvp.js instead.
  */
 
-const calculateCpMultiplier = (level) => {
-    if (level < 40) {
+const calculateCpMultiplier = (level, test = false) => {
+    if (test ? level < 40 : level <= 55) {
         return cpMultipliers[level];
     }
     const baseLevel = Math.floor(level);

--- a/src/services/pvp-core.js
+++ b/src/services/pvp-core.js
@@ -7,8 +7,21 @@ const cpMultipliers = require('../../static/data/cp_multiplier.json');
  * Use ./pvp.js instead.
  */
 
+const calculateCpMultiplier = (level) => {
+    if (level < 40) {
+        return cpMultipliers[level];
+    }
+    const baseLevel = Math.floor(level);
+    const baseCpm = Math.fround(0.5903 + baseLevel * 0.005);
+    if (baseLevel === level) {
+        return Math.fround(baseCpm);
+    }
+    const nextCpm = Math.fround(0.5903 + (baseLevel + 1) * 0.005);
+    return Math.sqrt((baseCpm * baseCpm + nextCpm * nextCpm) / 2);
+};
+
 const calculateStatProduct = (stats, attack, defense, stamina, level) => {
-    const multiplier = cpMultipliers[level];
+    const multiplier = calculateCpMultiplier(level);
     let hp = Math.floor((stamina + stats.stamina) * multiplier);
     if (hp < 10) {
         hp = 10;
@@ -19,7 +32,7 @@ const calculateStatProduct = (stats, attack, defense, stamina, level) => {
 };
 
 const calculateCP = (stats, attack, defense, stamina, level) => {
-    const multiplier = cpMultipliers[level];
+    const multiplier = calculateCpMultiplier(level);
 
     const a = stats.attack + attack;
     const d = stats.defense + defense;
@@ -73,4 +86,4 @@ const calculateRanks = (stats, cpCap, lvCap) => {
     return { combinations, sortedRanks };
 };
 
-module.exports = { calculateCP, calculateRanks };
+module.exports = { calculateCpMultiplier, calculateCP, calculateRanks };

--- a/src/services/pvp.js
+++ b/src/services/pvp.js
@@ -89,10 +89,10 @@ const queryPvPRank = async (pokemonId, formId, costumeId, attack, defense, stami
             if (last.cap < maxLevel) {
                 last.capped = true;
             } else {
-                entries.pop();
-                if (entries.length === 0) {
+                if (entries.length === 1) {
                     continue;
                 }
+                entries.pop();
             }
             result[leagueName] = result[leagueName] ? result[leagueName].concat(entries) : entries;
         }

--- a/src/services/pvp.js
+++ b/src/services/pvp.js
@@ -62,7 +62,7 @@ const queryPvPRank = async (pokemonId, formId, costumeId, attack, defense, stami
             for (const [lvCap, combinations] of Object.entries(combinationIndex)) {
                 const ivEntry = combinations[attack][defense][stamina];
                 if (lvCap >= maxLevel) {
-                    const [lastEntry] = result[leagueName].slice(-1);
+                    const [lastEntry] = (result[leagueName] || []).slice(-1);
                     if (lastEntry && ivEntry.level === lastEntry.level && ivEntry.rank === lastEntry.rank) {
                         lastEntry.capped = true;
                     }

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -1,9 +1,20 @@
 const assert = require('assert');
-const { calculateCP, calculateRanks } = require('../src/services/pvp-core.js');
+const { calculateCpMultiplier, calculateCP, calculateRanks } = require('../src/services/pvp-core.js');
 
+const cpMultipliers = require('../static/data/cp_multiplier.json');
 const masterfile = require('../static/data/masterfile.json');
 
 describe('PvP', () => {
+    it('calculateCpMultiplier', () => {
+        for (const [key, value] of Object.entries(cpMultipliers)) {
+            const level = parseFloat(key);
+            if (level < 40) {
+                continue;
+            }
+            // predicted CP multiplier must be consistent for L40+
+            assert.strictEqual(calculateCpMultiplier(level).toFixed(13), value.toFixed(13), 'CP multiplier at level ' + level);
+        }
+    });
     it('calculateCP', () => {
         assert.strictEqual(calculateCP(masterfile.pokemon[150], 15, 15, 15, 40), 4178, 'Mewtwo CP');
         assert.strictEqual(calculateCP(masterfile.pokemon[618], 15, 15, 15, 51), 2474, 'Stunfisk CP');

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -21,6 +21,7 @@ describe('PvP', () => {
     });
     it('calculateRanks', () => {
         assert.strictEqual(calculateRanks(masterfile.pokemon[26], 1500, 40).combinations[15][15][15].rank, 742, 'Hundo Raichu rank');
+        assert.strictEqual(calculateRanks(masterfile.pokemon[660], 1500, 100).combinations[0][15][11].rank, 1, 'Diggersby uncapped rank');
         assert.strictEqual(calculateRanks(masterfile.pokemon[663], 2500, 51).combinations[13][15][15].rank, 1, 'Talonflame functionally perfect @15');
         assert.strictEqual(calculateRanks(masterfile.pokemon[663], 2500, 51).combinations[13][15][14].rank, 1, 'Talonflame functionally perfect @14');
     });

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -12,7 +12,7 @@ describe('PvP', () => {
                 continue;
             }
             // predicted CP multiplier must be consistent for L40+
-            assert.strictEqual(calculateCpMultiplier(level).toFixed(13), value.toFixed(13), 'CP multiplier at level ' + level);
+            assert.strictEqual(calculateCpMultiplier(level, true).toFixed(13), value.toFixed(13), 'CP multiplier at level ' + level);
         }
     });
     it('calculateCP', () => {


### PR DESCRIPTION
Basically it sets `capped` more often (for example on level 50.5 Diggersby). It probably has the side effects of slightly reducing the size of `pokemon` table. Downside is that it will consume slightly more RAM (however it is unnoticeable in my test).