### PR TITLE
Little cup support

### DIFF
--- a/migrations/7.sql
+++ b/migrations/7.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pokemon
+    ADD COLUMN pvp TEXT DEFAULT NULL;

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -36,7 +36,7 @@
             ],
             "v1": true,
             "v2": true,
-            "v2Webhook": true,
+            "v2Webhook": false,
             "leagues": {
                 "little": 500,
                 "great": 1500,

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -31,11 +31,14 @@
             "rankCacheAge": 86400000,
             "levelCaps": [
                 40,
-                41,
                 50,
                 51
             ],
+            "v1": true,
+            "v2": true,
+            "v2Webhook": true,
             "leagues": {
+                "little": 500,
                 "great": 1500,
                 "ultra": 2500
             }

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -399,8 +399,9 @@ class Pokemon extends Model {
                 ultra: this.pvpRankingsUltraLeague,
             };
         } else {
-            message.pvp_rankings_great_league = config.dataparser.pvp.v2 ? this.pvp.great : this.pvpRankingsGreatLeague;
-            message.pvp_rankings_ultra_league = config.dataparser.pvp.v2 ? this.pvp.ultra : this.pvpRankingsUltraLeague;
+            const pvp = this.pvp || {};
+            message.pvp_rankings_great_league = config.dataparser.pvp.v2 ? pvp.great : this.pvpRankingsGreatLeague;
+            message.pvp_rankings_ultra_league = config.dataparser.pvp.v2 ? pvp.ultra : this.pvpRankingsUltraLeague;
         }
         return {
             type: 'pokemon',

--- a/static/data/masterfile.json
+++ b/static/data/masterfile.json
@@ -74,7 +74,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"2": {
 			"name": "Ivysaur",
@@ -288,7 +289,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"5": {
 			"name": "Charmeleon",
@@ -512,7 +514,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"8": {
 			"name": "Wartortle",
@@ -699,7 +702,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"11": {
 			"name": "Metapod",
@@ -867,7 +871,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"14": {
 			"name": "Kakuna",
@@ -1054,7 +1059,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"17": {
 			"name": "Pidgeotto",
@@ -1256,7 +1262,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"20": {
 			"name": "Raticate",
@@ -1378,7 +1385,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"22": {
 			"name": "Fearow",
@@ -1497,7 +1505,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"24": {
 			"name": "Arbok",
@@ -1815,7 +1824,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"28": {
 			"name": "Sandslash",
@@ -1956,7 +1966,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"30": {
 			"name": "Nidorina",
@@ -2147,7 +2158,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"33": {
 			"name": "Nidorino",
@@ -2463,7 +2475,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"38": {
 			"name": "Ninetales",
@@ -2710,7 +2723,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"42": {
 			"name": "Golbat",
@@ -2854,7 +2868,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"44": {
 			"name": "Gloom",
@@ -3044,7 +3059,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"47": {
 			"name": "Parasect",
@@ -3164,7 +3180,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"49": {
 			"name": "Venomoth",
@@ -3307,7 +3324,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"51": {
 			"name": "Dugtrio",
@@ -3493,7 +3511,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"53": {
 			"name": "Persian",
@@ -3630,7 +3649,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"55": {
 			"name": "Golduck",
@@ -3732,7 +3752,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"57": {
 			"name": "Primeape",
@@ -3851,7 +3872,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"59": {
 			"name": "Arcanine",
@@ -3971,7 +3993,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"61": {
 			"name": "Poliwhirl",
@@ -4179,7 +4202,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"64": {
 			"name": "Kadabra",
@@ -4383,7 +4407,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"67": {
 			"name": "Machoke",
@@ -4575,7 +4600,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"70": {
 			"name": "Weepinbell",
@@ -4750,7 +4776,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"73": {
 			"name": "Tentacruel",
@@ -4896,7 +4923,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"75": {
 			"name": "Graveler",
@@ -5156,7 +5184,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"78": {
 			"name": "Rapidash",
@@ -5327,7 +5356,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"80": {
 			"name": "Slowbro",
@@ -5469,7 +5499,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"82": {
 			"name": "Magneton",
@@ -5584,7 +5615,8 @@
 					],
 					"types": [
 						"Fighting"
-					]
+					],
+					"little": true
 				}
 			},
 			"default_form_id": 1023,
@@ -5670,7 +5702,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"85": {
 			"name": "Dodrio",
@@ -5770,7 +5803,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"87": {
 			"name": "Dewgong",
@@ -5914,7 +5948,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"89": {
 			"name": "Muk",
@@ -6055,7 +6090,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"91": {
 			"name": "Cloyster",
@@ -6157,7 +6193,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"93": {
 			"name": "Haunter",
@@ -6354,7 +6391,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"96": {
 			"name": "Drowzee",
@@ -6425,7 +6463,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"97": {
 			"name": "Hypno",
@@ -6547,7 +6586,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"99": {
 			"name": "Kingler",
@@ -6647,7 +6687,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"101": {
 			"name": "Electrode",
@@ -6767,7 +6808,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"103": {
 			"name": "Exeggutor",
@@ -6909,7 +6951,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"105": {
 			"name": "Marowak",
@@ -7125,7 +7168,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"109": {
 			"name": "Koffing",
@@ -7196,7 +7240,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"110": {
 			"name": "Weezing",
@@ -7336,7 +7381,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"112": {
 			"name": "Rhydon",
@@ -7531,7 +7577,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"115": {
 			"name": "Kangaskhan",
@@ -7664,7 +7711,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"117": {
 			"name": "Seadra",
@@ -7787,7 +7835,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"119": {
 			"name": "Seaking",
@@ -7886,7 +7935,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"121": {
 			"name": "Starmie",
@@ -8080,7 +8130,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"124": {
 			"name": "Jynx",
@@ -8453,7 +8504,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"130": {
 			"name": "Gyarados",
@@ -8690,7 +8742,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"134": {
 			"name": "Vaporeon",
@@ -8901,7 +8954,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"138": {
 			"name": "Omanyte",
@@ -8973,7 +9027,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"139": {
 			"name": "Omastar",
@@ -9093,7 +9148,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"141": {
 			"name": "Kabutops",
@@ -9473,7 +9529,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"148": {
 			"name": "Dragonair",
@@ -9820,7 +9877,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"153": {
 			"name": "Bayleef",
@@ -9971,7 +10029,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"156": {
 			"name": "Quilava",
@@ -10123,7 +10182,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"159": {
 			"name": "Croconaw",
@@ -10275,7 +10335,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"162": {
 			"name": "Furret",
@@ -10375,7 +10436,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"164": {
 			"name": "Noctowl",
@@ -10476,7 +10538,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"166": {
 			"name": "Ledian",
@@ -10577,7 +10640,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"168": {
 			"name": "Ariados",
@@ -10726,7 +10790,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"171": {
 			"name": "Lanturn",
@@ -10825,7 +10890,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"173": {
 			"name": "Cleffa",
@@ -10876,7 +10942,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"174": {
 			"name": "Igglybuff",
@@ -10928,7 +10995,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"175": {
 			"name": "Togepi",
@@ -10979,7 +11047,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"176": {
 			"name": "Togetic",
@@ -11085,7 +11154,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"178": {
 			"name": "Xatu",
@@ -11204,7 +11274,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"180": {
 			"name": "Flaaffy",
@@ -11657,7 +11728,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"188": {
 			"name": "Skiploom",
@@ -11849,7 +11921,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"191": {
 			"name": "Sunkern",
@@ -11901,7 +11974,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"192": {
 			"name": "Sunflora",
@@ -12002,7 +12076,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"194": {
 			"name": "Wooper",
@@ -12074,7 +12149,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"195": {
 			"name": "Quagsire",
@@ -12288,7 +12364,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"199": {
 			"name": "Slowking",
@@ -12410,7 +12487,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"201": {
 			"name": "Unown",
@@ -12723,7 +12801,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"205": {
 			"name": "Forretress",
@@ -12892,7 +12971,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"208": {
 			"name": "Steelix",
@@ -13026,7 +13106,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"210": {
 			"name": "Granbull",
@@ -13368,7 +13449,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"216": {
 			"name": "Teddiursa",
@@ -13439,7 +13521,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"217": {
 			"name": "Ursaring",
@@ -13539,7 +13622,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"219": {
 			"name": "Magcargo",
@@ -13659,7 +13743,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"221": {
 			"name": "Piloswine",
@@ -13835,7 +13920,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"224": {
 			"name": "Octillery",
@@ -14105,7 +14191,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"229": {
 			"name": "Houndoom",
@@ -14270,7 +14357,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"232": {
 			"name": "Donphan",
@@ -14535,7 +14623,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"237": {
 			"name": "Hitmontop",
@@ -14635,7 +14724,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"239": {
 			"name": "Elekid",
@@ -14686,7 +14776,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"240": {
 			"name": "Magby",
@@ -14737,7 +14828,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"241": {
 			"name": "Miltank",
@@ -15048,7 +15140,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"247": {
 			"name": "Pupitar",
@@ -15378,7 +15471,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"253": {
 			"name": "Grovyle",
@@ -15567,7 +15661,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"256": {
 			"name": "Combusken",
@@ -15773,7 +15868,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"259": {
 			"name": "Marshtomp",
@@ -15979,7 +16075,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"262": {
 			"name": "Mightyena",
@@ -16122,7 +16219,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"264": {
 			"name": "Linoone",
@@ -16249,7 +16347,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"266": {
 			"name": "Silcoon",
@@ -16497,7 +16596,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"271": {
 			"name": "Lombre",
@@ -16672,7 +16772,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"274": {
 			"name": "Nuzleaf",
@@ -16845,7 +16946,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"277": {
 			"name": "Swellow",
@@ -16946,7 +17048,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"279": {
 			"name": "Pelipper",
@@ -17067,7 +17170,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"281": {
 			"name": "Kirlia",
@@ -17275,7 +17379,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"284": {
 			"name": "Masquerain",
@@ -17377,7 +17482,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"286": {
 			"name": "Breloom",
@@ -17476,7 +17582,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"288": {
 			"name": "Vigoroth",
@@ -17627,7 +17734,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"291": {
 			"name": "Ninjask",
@@ -17775,7 +17883,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"294": {
 			"name": "Loudred",
@@ -17945,7 +18054,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"297": {
 			"name": "Hariyama",
@@ -18046,7 +18156,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"299": {
 			"name": "Nosepass",
@@ -18116,7 +18227,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"300": {
 			"name": "Skitty",
@@ -18168,7 +18280,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"301": {
 			"name": "Delcatty",
@@ -18423,7 +18536,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"305": {
 			"name": "Lairon",
@@ -18614,7 +18728,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"308": {
 			"name": "Medicham",
@@ -18748,7 +18863,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"310": {
 			"name": "Manectric",
@@ -19105,7 +19221,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"317": {
 			"name": "Swalot",
@@ -19225,7 +19342,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"319": {
 			"name": "Sharpedo",
@@ -19339,7 +19457,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"321": {
 			"name": "Wailord",
@@ -19439,7 +19558,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"323": {
 			"name": "Camerupt",
@@ -19601,7 +19721,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"326": {
 			"name": "Grumpig",
@@ -19834,7 +19955,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"329": {
 			"name": "Vibrava",
@@ -20026,7 +20148,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"332": {
 			"name": "Cacturne",
@@ -20128,7 +20251,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"334": {
 			"name": "Altaria",
@@ -20431,7 +20555,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"340": {
 			"name": "Whiscash",
@@ -20531,7 +20656,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"342": {
 			"name": "Crawdaunt",
@@ -20633,7 +20759,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"344": {
 			"name": "Claydol",
@@ -20757,7 +20884,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"346": {
 			"name": "Cradily",
@@ -20878,7 +21006,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"348": {
 			"name": "Armaldo",
@@ -20976,7 +21105,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"350": {
 			"name": "Milotic",
@@ -21235,7 +21365,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"354": {
 			"name": "Banette",
@@ -21367,7 +21498,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"356": {
 			"name": "Dusclops",
@@ -21646,7 +21778,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"361": {
 			"name": "Snorunt",
@@ -21702,7 +21835,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"362": {
 			"name": "Glalie",
@@ -21835,7 +21969,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"364": {
 			"name": "Sealeo",
@@ -22009,7 +22144,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"367": {
 			"name": "Huntail",
@@ -22269,7 +22405,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"372": {
 			"name": "Shelgon",
@@ -22472,7 +22609,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"375": {
 			"name": "Metang",
@@ -23227,7 +23365,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"388": {
 			"name": "Grotle",
@@ -23418,7 +23557,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"391": {
 			"name": "Monferno",
@@ -23590,7 +23730,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"394": {
 			"name": "Prinplup",
@@ -23762,7 +23903,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"397": {
 			"name": "Staravia",
@@ -23953,7 +24095,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"400": {
 			"name": "Bibarel",
@@ -24051,7 +24194,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"402": {
 			"name": "Kricketune",
@@ -24150,7 +24294,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"404": {
 			"name": "Luxio",
@@ -24302,7 +24447,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"407": {
 			"name": "Roserade",
@@ -24404,7 +24550,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"409": {
 			"name": "Rampardos",
@@ -24504,7 +24651,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"411": {
 			"name": "Bastiodon",
@@ -24653,7 +24801,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"413": {
 			"name": "Wormadam",
@@ -24848,7 +24997,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"416": {
 			"name": "Vespiquen",
@@ -24999,7 +25149,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"419": {
 			"name": "Floatzel",
@@ -25103,7 +25254,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"421": {
 			"name": "Cherrim",
@@ -25237,7 +25389,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"423": {
 			"name": "Gastrodon",
@@ -25393,7 +25546,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"426": {
 			"name": "Drifblim",
@@ -25492,7 +25646,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"428": {
 			"name": "Lopunny",
@@ -25700,7 +25855,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"432": {
 			"name": "Purugly",
@@ -25799,7 +25955,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"434": {
 			"name": "Stunky",
@@ -25871,7 +26028,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"435": {
 			"name": "Skuntank",
@@ -25973,7 +26131,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"437": {
 			"name": "Bronzong",
@@ -26076,7 +26235,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"439": {
 			"name": "Mime Jr",
@@ -26129,7 +26289,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"440": {
 			"name": "Happiny",
@@ -26179,7 +26340,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"441": {
 			"name": "Chatot",
@@ -26347,7 +26509,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"444": {
 			"name": "Gabite",
@@ -26534,7 +26697,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"447": {
 			"name": "Riolu",
@@ -26585,7 +26749,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"448": {
 			"name": "Lucario",
@@ -26720,7 +26885,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"450": {
 			"name": "Hippowdon",
@@ -26842,7 +27008,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"452": {
 			"name": "Drapion",
@@ -26946,7 +27113,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"454": {
 			"name": "Toxicroak",
@@ -27093,7 +27261,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"457": {
 			"name": "Lumineon",
@@ -27193,7 +27362,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"459": {
 			"name": "Snover",
@@ -27265,7 +27435,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"460": {
 			"name": "Abomasnow",
@@ -29219,7 +29390,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"496": {
 			"name": "Servine",
@@ -29370,7 +29542,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"499": {
 			"name": "Pignite",
@@ -29524,7 +29697,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"502": {
 			"name": "Dewott",
@@ -29675,7 +29849,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"505": {
 			"name": "Watchog",
@@ -29774,7 +29949,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"507": {
 			"name": "Herdier",
@@ -29926,7 +30102,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"510": {
 			"name": "Liepard",
@@ -30026,7 +30203,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"512": {
 			"name": "Simisage",
@@ -30125,7 +30303,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"514": {
 			"name": "Simisear",
@@ -30224,7 +30403,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"516": {
 			"name": "Simipour",
@@ -30323,7 +30503,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"518": {
 			"name": "Musharna",
@@ -30423,7 +30604,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"520": {
 			"name": "Tranquill",
@@ -30576,7 +30758,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"523": {
 			"name": "Zebstrika",
@@ -30675,7 +30858,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"525": {
 			"name": "Boldore",
@@ -30828,7 +31012,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"528": {
 			"name": "Swoobat",
@@ -30928,7 +31113,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"530": {
 			"name": "Excadrill",
@@ -31095,7 +31281,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"533": {
 			"name": "Gurdurr",
@@ -31246,7 +31433,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"536": {
 			"name": "Palpitoad",
@@ -31494,7 +31682,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"541": {
 			"name": "Swadloon",
@@ -31649,7 +31838,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"544": {
 			"name": "Whirlipede",
@@ -31804,7 +31994,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"547": {
 			"name": "Whimsicott",
@@ -31903,7 +32094,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"549": {
 			"name": "Lilligant",
@@ -32046,7 +32238,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"552": {
 			"name": "Krokorok",
@@ -32228,7 +32421,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"555": {
 			"name": "Darmanitan",
@@ -32422,7 +32616,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"558": {
 			"name": "Crustle",
@@ -32523,7 +32718,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"560": {
 			"name": "Scrafty",
@@ -32712,7 +32908,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"563": {
 			"name": "Cofagrigus",
@@ -32812,7 +33009,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"565": {
 			"name": "Carracosta",
@@ -32913,7 +33111,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"567": {
 			"name": "Archeops",
@@ -33013,7 +33212,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"569": {
 			"name": "Garbodor",
@@ -33113,7 +33313,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"571": {
 			"name": "Zoroark",
@@ -33212,7 +33413,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"573": {
 			"name": "Cinccino",
@@ -33311,7 +33513,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"575": {
 			"name": "Gothorita",
@@ -33462,7 +33665,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"578": {
 			"name": "Duosion",
@@ -33614,7 +33818,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"581": {
 			"name": "Swanna",
@@ -33714,7 +33919,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"583": {
 			"name": "Vanillish",
@@ -33889,7 +34095,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"586": {
 			"name": "Sawsbuck",
@@ -34043,7 +34250,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"589": {
 			"name": "Escavalier",
@@ -34145,7 +34353,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"591": {
 			"name": "Amoonguss",
@@ -34262,7 +34471,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"593": {
 			"name": "Jellicent",
@@ -34414,7 +34624,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"596": {
 			"name": "Galvantula",
@@ -34517,7 +34728,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"598": {
 			"name": "Ferrothorn",
@@ -34619,7 +34831,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"600": {
 			"name": "Klang",
@@ -34769,7 +34982,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"603": {
 			"name": "Eelektrik",
@@ -34921,7 +35135,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"606": {
 			"name": "Beheeyem",
@@ -35021,7 +35236,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"608": {
 			"name": "Lampent",
@@ -35176,7 +35392,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"611": {
 			"name": "Fraxure",
@@ -35337,7 +35554,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"614": {
 			"name": "Beartic",
@@ -35484,7 +35702,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"617": {
 			"name": "Accelgor",
@@ -35652,7 +35871,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"620": {
 			"name": "Mienshao",
@@ -35799,7 +36019,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"623": {
 			"name": "Golurk",
@@ -35900,7 +36121,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"625": {
 			"name": "Bisharp",
@@ -36050,7 +36272,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"628": {
 			"name": "Braviary",
@@ -36152,7 +36375,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"630": {
 			"name": "Mandibuzz",
@@ -36349,7 +36573,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"634": {
 			"name": "Zweilous",
@@ -36503,7 +36728,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"637": {
 			"name": "Volcarona",
@@ -37254,7 +37480,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"651": {
 			"name": "Quilladin",
@@ -37372,7 +37599,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"654": {
 			"name": "Braixen",
@@ -37490,7 +37718,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"657": {
 			"name": "Frogadier",
@@ -37607,7 +37836,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"660": {
 			"name": "Diggersby",
@@ -37685,7 +37915,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"662": {
 			"name": "Fletchinder",
@@ -37802,7 +38033,8 @@
 			"buddy_distance": 1,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"665": {
 			"name": "Spewpa",
@@ -38004,7 +38236,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 10000,
 			"third_move_candy": 25,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"668": {
 			"name": "Pyroar",
@@ -38115,7 +38348,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"670": {
 			"name": "Floette",
@@ -38267,7 +38501,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"673": {
 			"name": "Gogoat",
@@ -38342,7 +38577,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"675": {
 			"name": "Pangoro",
@@ -38501,7 +38737,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"678": {
 			"name": "Meowstic",
@@ -38589,7 +38826,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"680": {
 			"name": "Doublade",
@@ -38702,7 +38940,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"683": {
 			"name": "Aromatisse",
@@ -38774,7 +39013,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"685": {
 			"name": "Slurpuff",
@@ -38848,7 +39088,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"687": {
 			"name": "Malamar",
@@ -38924,7 +39165,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"689": {
 			"name": "Barbaracle",
@@ -39003,7 +39245,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"691": {
 			"name": "Dragalge",
@@ -39080,7 +39323,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"693": {
 			"name": "Clawitzer",
@@ -39155,7 +39399,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"695": {
 			"name": "Heliolisk",
@@ -39232,7 +39477,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"697": {
 			"name": "Tyrantrum",
@@ -39310,7 +39556,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"699": {
 			"name": "Aurorus",
@@ -39528,7 +39775,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"705": {
 			"name": "Sliggoo",
@@ -39680,7 +39928,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"709": {
 			"name": "Trevenant",
@@ -39770,7 +40019,8 @@
 			"mythic": false,
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
-			"third_move_candy": 75
+			"third_move_candy": 75,
+			"little": true
 		},
 		"711": {
 			"name": "Gourgeist",
@@ -39859,7 +40109,8 @@
 			"buddy_distance": 3,
 			"third_move_stardust": 50000,
 			"third_move_candy": 50,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"713": {
 			"name": "Avalugg",
@@ -39936,7 +40187,8 @@
 			"buddy_distance": 5,
 			"third_move_stardust": 75000,
 			"third_move_candy": 75,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"715": {
 			"name": "Noivern",
@@ -40183,7 +40435,8 @@
 			"buddy_distance": 20,
 			"third_move_stardust": 100000,
 			"third_move_candy": 100,
-			"gym_defender_eligible": true
+			"gym_defender_eligible": true,
+			"little": true
 		},
 		"809": {
 			"name": "Melmetal",


### PR DESCRIPTION
New config options: `v1`/`v2` for writing `pvp_rankings_*` or `pvp` to `pokemon` table, `v2Webhook` for enabling sending new pvp data to webhook.

Goes with: https://github.com/WatWowMap/Masterfile-Generator/pull/18

Oh I also removed level cap 41 from `default.json`.