### PR TITLE
Only include futureproof IV combinations

### DIFF
--- a/src/services/pvp-core.js
+++ b/src/services/pvp-core.js
@@ -20,15 +20,15 @@ const calculateCpMultiplier = (level, test = false) => {
     return Math.sqrt((baseCpm * baseCpm + nextCpm * nextCpm) / 2);
 };
 
-const calculateStatProduct = (stats, attack, defense, stamina, level) => {
+const calculateStats = (stats, attack, defense, stamina, level) => {
     const multiplier = calculateCpMultiplier(level);
-    let hp = Math.floor((stamina + stats.stamina) * multiplier);
-    if (hp < 10) {
-        hp = 10;
-    }
-    return (attack + stats.attack) * multiplier *
-        (defense + stats.defense) * multiplier *
-        hp;
+    const hp = Math.floor((stamina + stats.stamina) * multiplier);
+    return {
+        atk: (attack + stats.attack) * multiplier,
+        def: (defense + stats.defense) * multiplier,
+        sta: hp < 10 ? 10 : hp,
+        level,
+    };
 };
 
 const calculateCP = (stats, attack, defense, stamina, level) => {
@@ -54,8 +54,14 @@ const calculatePvPStat = (stats, attack, defense, stamina, cap, lvCap) => {
         }
     }
     // TODO: currently we assume lv1 cp is always below cpCap. If this is not the case, we need to add a check here
-    return { value: calculateStatProduct(stats, attack, defense, stamina, lowest), level: lowest, cp: bestCP };
+    const result = calculateStats(stats, attack, defense, stamina, lowest);
+    result.cp = bestCP;
+    result.value = result.atk * result.def * result.sta;
+    return result;
 };
+
+const strictlyDominates = (a, b) => a.atk >= b.atk && a.def >= b.def && a.sta >= b.sta &&
+    (a.atk !== b.atk || a.def !== b.def || a.sta !== b.sta);
 
 const calculateRanks = (stats, cpCap, lvCap) => {
     const combinations = [];
@@ -67,21 +73,47 @@ const calculateRanks = (stats, cpCap, lvCap) => {
             for (let s = 0; s <= 15; s++) {
                 const currentStat = calculatePvPStat(stats, a, d, s, cpCap, lvCap);
                 arrD.push(currentStat);
+                for (const other of sortedRanks) {
+                    if (other.rank === null) {
+                        continue;
+                    }
+                    if (strictlyDominates(other, currentStat)) {
+                        currentStat.rank = null;
+                        break;
+                    }
+                    if (strictlyDominates(currentStat, other)) {
+                        other.rank = null;
+                    }
+                }
                 sortedRanks.push(currentStat);
             }
             arrA.push(arrD);
         }
         combinations.push(arrA);
     }
-    sortedRanks.sort((a, b) => b.value - a.value);
-    const best = sortedRanks[0].value;
-    for (let i = 0, j = 0; i < sortedRanks.length; i++) {
-        const entry = sortedRanks[i];
-        entry.percentage = Number((entry.value / best).toFixed(5));
-        if (entry.value < sortedRanks[j].value) {
-            j = i;
+    sortedRanks.sort((a, b) => {
+        const d = b.value - a.value;
+        return d === 0 ? a.sta - b.sta : d;
+    });
+    let lastStat, nextRank = 1;
+    for (const stat of sortedRanks) {
+        if (stat.rank === null) {
+            continue;
         }
-        entry.rank = j + 1;
+        if (lastStat === undefined || stat.value < lastStat.value) {
+            lastStat = stat;
+            stat.rank = nextRank;
+        } else {
+            stat.rank = lastStat.rank;
+        }
+        ++nextRank;
+    }
+    const best = sortedRanks[0].value, worst = lastStat.value;
+    for (const stat of sortedRanks) {
+        stat.percentage = best === worst ? stat.value === best ? 1 : -Infinity : (stat.value - worst) / (best - worst);
+        delete stat.atk;
+        delete stat.def;
+        delete stat.sta;
     }
     return { combinations, sortedRanks };
 };

--- a/src/services/pvp.js
+++ b/src/services/pvp.js
@@ -65,7 +65,7 @@ const queryPvPRank = async (pokemonId, formId, costumeId, attack, defense, stami
             const entries = [];
             for (const [lvCap, combinations] of Object.entries(combinationIndex)) {
                 const ivEntry = combinations[attack][defense][stamina];
-                if (level > ivEntry.level) {
+                if (ivEntry.rank === null || level > ivEntry.level) {
                     continue;
                 }
                 const entry = { ...baseEntry, cap: parseFloat(lvCap), ...ivEntry };

--- a/test/pvp-core.js
+++ b/test/pvp-core.js
@@ -20,8 +20,8 @@ describe('PvP', () => {
         assert.strictEqual(calculateCP(masterfile.pokemon[618], 15, 15, 15, 51), 2474, 'Stunfisk CP');
     });
     it('calculateRanks', () => {
-        assert.strictEqual(calculateRanks(masterfile.pokemon[26], 1500, 40).combinations[15][15][15].rank, 742, 'Hundo Raichu rank');
-        assert.strictEqual(calculateRanks(masterfile.pokemon[351], 1500, 51).combinations[4][14][15].rank, 56, 'Weather boosted Castform rank');
+        assert.strictEqual(calculateRanks(masterfile.pokemon[26], 1500, 40).combinations[15][15][15].rank, null, 'Hundo Raichu rank');
+        assert.strictEqual(calculateRanks(masterfile.pokemon[351], 1500, 51).combinations[4][14][15].rank, 32, 'Weather boosted Castform rank');
         assert.strictEqual(calculateRanks(masterfile.pokemon[660], 1500, 100).combinations[0][15][11].rank, 1, 'Diggersby uncapped rank');
         assert.strictEqual(calculateRanks(masterfile.pokemon[663], 2500, 51).combinations[13][15][15].rank, 1, 'Talonflame functionally perfect @15');
         assert.strictEqual(calculateRanks(masterfile.pokemon[663], 2500, 51).combinations[13][15][14].rank, 1, 'Talonflame functionally perfect @14');


### PR DESCRIPTION
**Controversial changes ahead**

This PR aims to drastically reduces the number of PvP rows. For example, a L4 14/2/13 Eevee will only have 2 PvP results, instead of 17:

```json
{
 "little":[{"pokemon":133,"cap":40,"level":17.5,"cp":500,"value":376168,"rank":306,"percentage":0.2033091438582841,"capped":true}],
 "great":[{"pokemon":197,"cap":40,"level":25.5,"cp":1499,"value":2374288,"rank":238,"percentage":0.19891700174497112,"capped":true}]
}
```

Another example of L3 0/15/12 Eevee:

```json
{
 "great":[
  {"pokemon":135,"cap":40,"level":19.5,"cp":1498,"value":1638062,"rank":2,"percentage":0.9427872188994469,"capped":true},
  {"pokemon":471,"cap":40,"level":18,"cp":1500,"value":1665040,"rank":1,"percentage":1,"capped":true},
  {"pokemon":700,"cap":40,"level":18.5,"cp":1500,"value":1931410,"rank":1,"percentage":1,"capped":true}
 ],
 "ultra":[
  {"pokemon":135,"cap":40,"level":35,"cp":2498,"value":3525481,"rank":4,"percentage":0.9009121293377806,"capped":true},
  {"pokemon":470,"cap":40,"level":34,"cp":2496,"value":3810006,"rank":3,"percentage":0.9507277014391412,"capped":true},
  {"pokemon":471,"cap":40,"level":30,"cp":2500,"value":3588192,"rank":1,"percentage":1,"capped":true}
 ]
}
```

As opposed to:

```
Great League:
- Vaporeon #86 @1485CP (Lvl. 18)
- Jolteon #2 @1498CP (Lvl. 19.5)
- Flareon #6 @1496CP (Lvl. 18.5)
- Espeon #112 @1486CP (Lvl. 17.5)
- Umbreon #40 @1490CP (Lvl. 27.5)
- Leafeon #242 @1481CP (Lvl. 19)
- Glaceon #1 @1500CP (Lvl. 18)
- Sylveon #1 @1500CP (Lvl. 18.5)

Ultra League:
- Vaporeon #3 @2495CP (Lvl. 30.5)
- Jolteon #5 @2498CP (Lvl. 35)
- Flareon #59 @2487CP (Lvl. 31.5)
- Espeon #583 @2463CP (Lvl. 29)
- Leafeon #3 @2496CP (Lvl. 34)
- Glaceon #1 @2500CP (Lvl. 30)
- Sylveon #22 @2494CP (Lvl. 31.5)

Little Cup:
- Eevee #267 @490CP (Lvl. 18.5)
```

Essentially, all "suboptimal" IVs are filtered out from the rankings. An IV combination is suboptimal if there is another IV combination that strictly beats it, that is having not worse stats (atk/def/sta) and at least one of them is better.

Furthermore, percentage is rescaled among the rest of the combinations. This new ranking system could be explored here: https://codepen.io/Mygod/full/qBRGbBo