### PR TITLE
Stop processing level cap 40 by default

### DIFF
--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -30,7 +30,6 @@
         "pvp": {
             "rankCacheAge": 86400000,
             "levelCaps": [
-                40,
                 50,
                 51
             ],


### PR DESCRIPTION
More justifications: pvpoke has started ranking XL Pokemon by default.