### PR TITLE
Support detection of A/B spawn

### DIFF
--- a/migrations/9.sql
+++ b/migrations/9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pokemon
+    ADD COLUMN `alternative_displays` TEXT DEFAULT NULL;

--- a/src/models/pokemon-display.js
+++ b/src/models/pokemon-display.js
@@ -1,3 +1,5 @@
+const util = require('util');
+
 class PokemonDisplay {
     /**
      * Two PokemonProtos are considered the same spawn if they have the same PokemonDisplay.
@@ -27,6 +29,10 @@ class PokemonDisplay {
 
     toString() {
         return `${this.pokemonId},${this.form},${this.costume},${this.gender}`;
+    }
+
+    [util.inspect.custom]() {
+        return this.toString();
     }
 }
 

--- a/src/models/pokemon-display.js
+++ b/src/models/pokemon-display.js
@@ -1,0 +1,33 @@
+class PokemonDisplay {
+    /**
+     * Two PokemonProtos are considered the same spawn if they have the same PokemonDisplay.
+     *
+     * @param pokemonId
+     * @param form
+     * @param costume
+     * @param gender
+     */
+    constructor(pokemonId, form, costume, gender) {
+        this.pokemonId = pokemonId;
+        this.form = form;
+        this.costume = costume;
+        this.gender = gender;
+    }
+
+    static fromProtos(pokemonId, display) {
+        return new PokemonDisplay(pokemonId, display.form, display.costume, display.gender);
+    }
+
+    equals(other) {
+        return this.pokemonId === other.pokemonId &&
+            this.form === other.form &&
+            this.costume === other.costume &&
+            this.gender === other.gender;
+    }
+
+    toString() {
+        return `${this.pokemonId},${this.form},${this.costume},${this.gender}`;
+    }
+}
+
+module.exports = PokemonDisplay;

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -484,6 +484,7 @@ class Pokemon extends Model {
             shiny: this.shiny,
             username: this.username,
             display_pokemon_id: this.displayPokemonId,
+            has_alternative_displays: this.hasAlternativeDisplays(),
         };
         if (config.dataparser.pvp.v2Webhook) {
             message.pvp = config.dataparser.pvp.v2 ? this.pvp : {

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -78,8 +78,13 @@ class Pokemon extends Model {
     }
 
     hasAlternativeDisplays(current = this._getPokemonDisplay()) {
-        return this.alternativeDisplays !== null && (Object.keys(this.alternativeDisplays).length > 1 ||
-            this.alternativeDisplays[current.toString()] === undefined);
+        if (this.alternativeDisplays === null) return false;
+        if (typeof this.alternativeDisplays === 'string') {
+            // more sequelize bs: https://github.com/sequelize/sequelize/issues/11177#issuecomment-877873907
+            this.alternativeDisplays = JSON.parse(this.alternativeDisplays);
+        }
+        return Object.keys(this.alternativeDisplays).length > 1 ||
+            this.alternativeDisplays[current.toString()] === undefined;
     }
 
     _setPokemonDisplay(pokemonId, display, username) {
@@ -89,7 +94,7 @@ class Pokemon extends Model {
                 const oldKey = old.toString();
                 const oldTime = this.previous().updated;
                 if (this.alternativeDisplays !== null) {
-                    // more suffering: https://github.com/sequelize/sequelize/issues/11177#issuecomment-877873907
+                    // more sequelize bs: https://github.com/sequelize/sequelize/issues/11177#issuecomment-877873907
                     this.alternativeDisplays = JSON.parse(this.alternativeDisplays);
                     for (const [key, lookup] of Object.entries(this.alternativeDisplays)) {
                         lookup[username] !== undefined && delete lookup[username] &&


### PR DESCRIPTION
`alternative_displays` column will be a text field storing a json of PokemonDisplay mapping to mappings from usernames to last seen timestamps, for example: `{"276,0,0,2":{"scanner2":1626044444,"scanner3":1626044444}}`

The last scanner that scans the Pokemon wins the tie. Everyone else goes into this new field.

To test whether a spawn might be A/B spawn, use:
```js
alternative_displays !== null && (Object.keys(alternative_displays).length > 1 ||
    alternative_displays[`${pokemon_id},${form},${costume},${gender}`] === undefined)
```