### PR TITLE
Support multi-incident on the same pokestop

### DIFF
--- a/migrations/11.sql
+++ b/migrations/11.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS `incident` (
+    `id` bigint(20) NOT NULL,
+    `pokestop_id` varchar(128) NOT NULL,
+    `start_ms` bigint(20) NOT NULL,
+    `expiration_ms` bigint(20) NOT NULL,
+    `character` int(2) NOT NULL,
+    `updated_ms` bigint(20) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `ix_pokestop` (`pokestop_id`, `expiration_ms`),
+    CONSTRAINT `fk_incident_pokestop_id` FOREIGN KEY (`pokestop_id`) REFERENCES `pokestop` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -27,6 +27,19 @@
         "pokemonTimeUnseen": 20,
         "pokemonTimeReseen": 10,
         "lureTime": 30,
+        "incident": {
+            "v1": true,
+            "v1priority": [
+                99,
+                1,
+                5,
+                6,
+                2,
+                3,
+                4
+            ],
+            "v2": true
+        },
         "pvp": {
             "rankCacheAge": 86400000,
             "levelCaps": [

--- a/src/models/incident.js
+++ b/src/models/incident.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { DataTypes, Model } = require('sequelize');
+const sequelize = require('../services/sequelize.js');
+const WebhookController = require('../services/webhook.js');
+const Pokestop = require('./pokestop.js');
+
+/**
+ * Incident model class.
+ */
+class Incident extends Model {
+    static fromFortFields = [
+        'id',
+        'pokestopId',
+        'startMs',
+        'expirationMs',
+        // 'displayType',
+        'character',
+        // 'pokestopStyle',
+        'updatedMs',
+    ];
+    static fromIncidentDisplay(ms, pokestopId, incidentDisplay) {
+        return Incident.build({
+            id: incidentDisplay.incident_id,
+            pokestopId,
+            startMs: incidentDisplay.incident_start_ms,
+            expirationMs: incidentDisplay.incident_expiration_ms,
+            // displayType: incidentDisplay.incident_display_type,
+            character: incidentDisplay.character_display.character,
+            // pokestopStyle: incidentDisplay.character_display.style,
+            updatedMs: ms,
+        });
+    }
+
+    async triggerWebhook(pokestop, oldPokestop) {
+        let oldIncident = null;
+        try {
+            oldIncident = await Incident.findByPk(this.id);
+        } catch { }
+        if (!oldIncident || (oldIncident.expirationMs || 0) < (this.expirationMs || 0)) {
+            WebhookController.instance.addInvasionEvent(this.toJson('invasion', oldPokestop));
+        }
+        return false;
+    }
+
+    toJson(pokestop, oldPokestop) {
+        return {
+            type: "invasion",
+            message: {
+                pokestop_id: pokestop.id,
+                latitude: pokestop.lat,
+                longitude: pokestop.lon,
+                pokestop_name: pokestop.name || oldPokestop && oldPokestop.name || "Unknown",
+                url: pokestop.url || oldPokestop && oldPokestop.url,
+                lure_expiration: pokestop.lureExpireTimestamp || 0,
+                last_modified: pokestop.lastModifiedTimestamp || 0,
+                enabled: pokestop.enabled || true,
+                lure_id: pokestop.lureId || 0,
+                // pokestop_display: this.displayType,
+                incident_expire_timestamp: this.expirationMs / 1000,
+                grunt_type: this.character,
+                updated: this.updatedMs / 1000,
+            }
+        };
+    }
+}
+Incident.init({
+    id: {
+        type: DataTypes.BIGINT(20),
+        primaryKey: true,
+        allowNull: false,
+    },
+    startMs: {
+        type: DataTypes.BIGINT(20),
+        allowNull: false,
+    },
+    expirationMs: {
+        type: DataTypes.BIGINT(20),
+        allowNull: false,
+    },
+    // displayType: {
+    //     type: DataTypes.INTEGER(2),
+    //     allowNull: false,
+    //     defaultValue: 0,
+    // },
+    character: {
+        type: DataTypes.INTEGER(2),
+        allowNull: false,
+    },
+    // style: {
+    //     type: DataTypes.INTEGER(2),
+    //     allowNull: false,
+    //     defaultValue: 0,
+    // },
+    updatedMs: {
+        type: DataTypes.BIGINT(20),
+        allowNull: false,
+    },
+}, {
+    sequelize,
+    timestamps: false,
+    underscored: true,
+    indexes: [
+        {
+            name: 'ix_pokestop',
+            fields: ['pokestopId', 'expirationMs'],
+        },
+    ],
+    tableName: 'incident',
+});
+
+// Export the class
+module.exports = Incident;

--- a/src/models/incident.js
+++ b/src/models/incident.js
@@ -10,7 +10,6 @@ const Pokestop = require('./pokestop.js');
  */
 class Incident extends Model {
     static fromFortFields = [
-        'id',
         'pokestopId',
         'startMs',
         'expirationMs',

--- a/src/models/pokestop.js
+++ b/src/models/pokestop.js
@@ -5,7 +5,8 @@ const POGOProtos = require('pogo-protos');
 const { DataTypes, Model, Op, Sequelize } = require('sequelize');
 const sequelize = require('../services/sequelize.js');
 const WebhookController = require('../services/webhook.js');
-const Cell = require('./cell');
+const Cell = require('./cell.js');
+const Incident = require('./incident.js');
 const config = require('../services/config.js');
 
 /**
@@ -31,7 +32,8 @@ class Pokestop extends Model {
         'arScanEligible',
     ];
     static fromFort(cellId, fort) {
-        let ts = new Date().getTime() / 1000;
+        const now = Date.now();
+        const ts = now / 1000;
         const record = {
             id: fort.fort_id,
             lat: fort.latitude,
@@ -56,20 +58,29 @@ class Pokestop extends Model {
             }
             record.lureId = fort.active_fort_modifier[0];
         }
-        if (fort.pokestop_display) {
-            record.incidentExpireTimestamp = Math.floor(fort.pokestop_display.incident_expiration_ms / 1000);
-            if (fort.pokestop_display.character_display) {
-                record.pokestopDisplay = fort.pokestop_display.character_display.style;
-                record.gruntType = fort.pokestop_display.character_display.character;
-            }
-        } else if (fort.pokestop_displays && fort.pokestop_displays.length > 0) {
-            record.incidentExpireTimestamp = Math.floor(fort.pokestop_displays[0].incident_expiration_ms / 1000);
-            if (fort.pokestop_displays[0].character_display) {
-                record.pokestopDisplay = fort.pokestop_displays[0].character_display.style;
-                record.gruntType = fort.pokestop_displays[0].character_display.character;
+        let incidents = [];
+        if (config.dataparser.incident.v1 || config.dataparser.incident.v2) {
+            incidents = fort.pokestop_displays;
+            if (!incidents && fort.pokestop_display) incidents = [fort.pokestop_display];
+            if (incidents && incidents.length > 0) {
+                if (config.dataparser.incident.v1) {
+                    const priorities = config.dataparser.incident.v1priority;
+                    let incident, priority = priorities[0] + 1;
+                    for (const i of incidents) {
+                        const mine = priorities[i.incident_display_type] || priorities[0];
+                        if (mine >= priority) continue;
+                        priority = mine;
+                        incident = i;
+                    }
+                    record.incidentExpireTimestamp = Math.floor(incident.incident_expiration_ms / 1000);
+                    record.pokestopDisplay = incident.character_display.style;
+                    record.gruntType = incident.character_display.character;
+                }
+                incidents = config.dataparser.incident.v2 ? incidents.map(id =>
+                    Incident.fromIncidentDisplay(now, record.id, id)) : [];
             }
         }
-        return Pokestop.build(record);
+        return [Pokestop.build(record), incidents];
     }
 
     static fromQuestFields = [
@@ -260,7 +271,7 @@ class Pokestop extends Model {
     /**
      * Update Pokestop values if changed from already found Pokestop
      */
-    async triggerWebhook(updateQuest) {
+    async triggerWebhook(updateQuest, incidents) {
         let oldPokestop = null;
         try {
             oldPokestop = await Pokestop.findByPk(this.id);
@@ -283,7 +294,9 @@ class Pokestop extends Model {
             if ((oldPokestop.lureExpireTimestamp || 0) < (this.lureExpireTimestamp || 0)) {
                 WebhookController.instance.addLureEvent(this.toJson('lure', oldPokestop));
             }
-            if ((oldPokestop.incidentExpireTimestamp || 0) < (this.incidentExpireTimestamp || 0)) {
+            if (config.dataparser.incident.v2) {
+                if (incidents) await Promise.all(incidents.map(incident => incident.triggerWebhook(this, oldPokestop)));
+            } else if ((oldPokestop.incidentExpireTimestamp || 0) < (this.incidentExpireTimestamp || 0)) {
                 WebhookController.instance.addInvasionEvent(this.toJson('invasion', oldPokestop));
             }
         }
@@ -559,6 +572,9 @@ Cell.Pokestops = Cell.hasMany(Pokestop, {
     foreignKey: 'cellId',
 });
 Pokestop.Cell = Pokestop.belongsTo(Cell);
+
+Incident.Pokestop = Incident.belongsTo(Pokestop, { foreignKey: 'pokestopId' });
+Pokestop.Incidents = Pokestop.hasMany(Incident, { foreignKey: 'pokestopId' });
 
 // Export the class
 module.exports = Pokestop;

--- a/src/models/pokestop.js
+++ b/src/models/pokestop.js
@@ -425,8 +425,6 @@ class Pokestop extends Model {
                         last_modified: this.lastModifiedTimestamp || 0,
                         enabled: this.enabled || true,
                         lure_id: this.lureId || 0,
-                        pokestop_display: this.pokestopDisplay || 0,
-                        incident_expire_timestamp: this.incidentExpireTimestamp || 0,
                         ar_scan_eligible: this.arScanEligible,
                         updated: this.updated || 1
                     }


### PR DESCRIPTION
Support multiple incidents parsing. The new behavior can be enabled via `config.dataparser.incident.v2`, while the old database will be updated if `config.dataparser.incident.v1 = true`. Furthermore, the highest priority incident will be populated into the `pokestop` table configured by `config.dataparser.incident.v1priority` depending on their category.

New `incident` table! Unused columns that could be added later:

* `display_type`: invasion category -- grunts/leaders/npcs.
* `pokestop_style`: whether the pokestop should turn black. This was already in rdm/chuck before the PR.

Breaking change: `pokestop_display` is no longer being sent in webhooks.