### PR TITLE
Add v2 lure

### DIFF
--- a/migrations/12.sql
+++ b/migrations/12.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `pokestop`
+    ADD COLUMN `lure_first_seen_timestamp` int(11) unsigned NOT NULL DEFAULT 0,
+    MODIFY COLUMN `lure_expire_timestamp` int(11) unsigned DEFAULT 0;
+UPDATE `pokestop` SET `lure_expire_timestamp` = 0 WHERE `lure_expire_timestamp` IS NULL OR `lure_expire_timestamp` < UNIX_TIMESTAMP();

--- a/src/configs/default.json
+++ b/src/configs/default.json
@@ -40,6 +40,10 @@
             ],
             "v2": true
         },
+        "lure": {
+            "v2": false,
+            "v2Webhook": false
+        },
         "pvp": {
             "rankCacheAge": 86400000,
             "levelCaps": [

--- a/src/services/consumer.js
+++ b/src/services/consumer.js
@@ -128,6 +128,7 @@ class Consumer {
         'url',
         'updated',
     ];
+    static fortStopColumns = Consumer.fortColumns.concat(Pokestop.fromFortDetailsColumnsAdditional);
 
     async updateFortDetails(fortDetails) {
         // Update Forts
@@ -152,7 +153,7 @@ class Consumer {
                         updatedGyms.push(record);
                         break;
                     case POGOProtos.Rpc.FortType.CHECKPOINT:
-                        updatedPokestops.push(record);
+                        updatedPokestops.push(Pokestop.fromFortDetails(record));
                         break;
                 }
             }
@@ -171,7 +172,7 @@ class Consumer {
             if (updatedPokestops.length > 0) {
                 try {
                     const result = await Pokestop.bulkCreate(updatedPokestops.sort(stringCompare('id')), {
-                        updateOnDuplicate: Consumer.fortColumns,
+                        updateOnDuplicate: Consumer.fortStopColumns,
                     });
                     //console.log('[FortDetails] Result:', result.length);
                 } catch (err) {


### PR DESCRIPTION
* Support remembering lure first seen, so that estimated lure duration can be more robust, and moved to front end.
* Support scanning lure true expiration time when the stop is clicked.

New config options: `dataparser.lure.v2` enables the new behavior and `dataparser.lure.v2Webhook` enables the new behavior for the webhook as well.

Changes in behavior for v2: `lure_expiration_time` now stores `NULL` if the lure is active and has unknown expiration time, and `0` if there is not a lure when the stop is last scanned.